### PR TITLE
Update broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project is licensed under the terms of the MIT open source license. Please 
 
 ## Maintainers 
 
-You can find the list of maintainers in [CODEOWNERS](./.github/CODE_OF_CONDUCT.md)
+You can find the list of maintainers in [CODEOWNERS](./.github/CODEOWNERS)
 
 ## Support
 


### PR DESCRIPTION
This pull request includes a small fix to the `README.md` file. The change corrects the link to the `CODEOWNERS` file, ensuring that users can find the list of maintainers easily.